### PR TITLE
Change nullable signature on Field

### DIFF
--- a/src/PersianDate.php
+++ b/src/PersianDate.php
@@ -51,7 +51,7 @@ class PersianDate extends Field
      *
      * @return $this
      */
-    public function nullable()
+    public function nullable($nullable = true, $values = null)
     {
         return $this->withMeta(['nullable' => true]);
     }

--- a/src/PersianDateTime.php
+++ b/src/PersianDateTime.php
@@ -51,7 +51,7 @@ class PersianDateTime extends Field
      *
      * @return $this
      */
-    public function nullable()
+    public function nullable($nullable = true, $values = null)
     {
         return $this->withMeta(['nullable' => true]);
     }


### PR DESCRIPTION
On Laravel Nova 2 it throw an exception with this content:
message: "Declaration of Aloko\PersianDatepicker\PersianDate::nullable() should be compatible with Laravel\Nova\Fields\Field::nullable($nullable = true, $values = NULL)"
